### PR TITLE
fix: healthcheck endpoint during graceful shutdown

### DIFF
--- a/health.go
+++ b/health.go
@@ -27,7 +27,7 @@ func NewHealthHandler(sr map[string]Checker, shutdownInitiated *atomic.Pointer[b
 
 func (rd *Health) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if rd.shutdownInitiated != nil && *rd.shutdownInitiated.Load() {
-		http.Error(w, "service is shutting down", http.StatusServiceUnavailable)
+		http.Error(w, "service is shutting down", http.StatusOK)
 		return
 	}
 

--- a/tests/plugin_test.go
+++ b/tests/plugin_test.go
@@ -569,6 +569,15 @@ func TestShutdown503(t *testing.T) {
 	rsp, err := httpClient.Do(req)
 	require.NoError(t, err)
 
+	assert.Equal(t, http.StatusOK, rsp.StatusCode)
+
+	req, err = http.NewRequestWithContext(context.Background(), http.MethodGet, "http://127.0.0.1:34711/ready", nil)
+	assert.NoError(t, err)
+	require.NotNil(t, req)
+
+	rsp, err = httpClient.Do(req)
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusServiceUnavailable, rsp.StatusCode)
 
 	wg.Wait()


### PR DESCRIPTION
# Reason for This PR

Follow up for https://github.com/roadrunner-server/status/pull/65

## Description of Changes

During shutdown
/health endpoint should returns 200
/ready endpoint should returns 503

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where the service incorrectly returned a Service Unavailable status during shutdown. It now correctly returns an OK status.

- **Tests**
  - Enhanced tests to validate the correct status codes during service shutdown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->